### PR TITLE
Dockerfile: use lts version instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest as ts-environment
+FROM node:lts-alpine as ts-environment
 WORKDIR /usr/app
 
 COPY package.json ./


### PR DESCRIPTION
# Summary

In order to make the cron job work, I had to use the LTS version!

# Issue addressed

Close https://github.com/KarpatkeyDAO/karpatkey-api-service/issues/27

# Test Plan

### Manual Testing

- [ ] 1.

- [ ] 2.

- [ ] 3.

### Visual changes

_Screenshots_ or _loom_

### Deployment

- [ ] Any special requests before or after deploying

# Reviewer

- [ ] Changes work as expected (according to requirements)
- [ ] Tested that complete user journey works as expected
- [ ] Manually tested
- [ ] Unit/acceptance specs
